### PR TITLE
Add precision as argument

### DIFF
--- a/difference.go
+++ b/difference.go
@@ -1,8 +1,8 @@
 package difference
 
 import (
-    "errors"
-    "math"
+	"errors"
+	"math"
 )
 
 /*
@@ -12,12 +12,13 @@ If result is positive, there is an increase.
 If result is negative, there is a decrease.
 Initial value cannot be zero.
 */
-func PercentChange(initial float64, final float64) (float64, error) {
-    if initial == 0 {
-        return 0, errors.New("Initial value should be non-zero")
-    }
-    diff := final - initial
-    return diff / math.Abs(initial) * 100, nil
+func PercentChange(initial float64, final float64, precision uint) (float64, error) {
+	if initial == 0 {
+		return 0, errors.New("Initial value should be non-zero")
+	}
+	diff := final - initial
+	result := diff / math.Abs(initial) * 100
+	return roundFloat(result, precision), nil
 }
 
 /*
@@ -26,11 +27,20 @@ It calculates absolute difference, divides it with average value, and multiplies
 by 100 to get percent difference.
 Both values must be greater than zero.
 */
-func PercentDifference(n1 float64, n2 float64) (float64, error) {
-    if n1 <= 0 || n2 <= 0 {
-        return 0, errors.New("Values should be greater than 0")
-    }
-    diff := math.Abs(n1 - n2)
-    average := (n1 + n2) / 2
-    return (diff / average * 100), nil
+func PercentDifference(n1 float64, n2 float64, precision uint) (float64, error) {
+	if n1 <= 0 || n2 <= 0 {
+		return 0, errors.New("Values should be greater than 0")
+	}
+	diff := math.Abs(n1 - n2)
+	average := (n1 + n2) / 2
+	result := (diff / average * 100)
+	return roundFloat(result, precision), nil
+}
+
+/*
+roundFloat is a helper function that rounds a value of float64 type to a specific precision.
+*/
+func roundFloat(value float64, precision uint) float64 {
+	divisor := math.Pow(10, float64(precision))
+	return math.Round(value*divisor) / divisor
 }

--- a/difference_test.go
+++ b/difference_test.go
@@ -11,28 +11,29 @@ func TestPercentChange(t *testing.T) {
 		testname      string
 		initial       float64
 		final         float64
+		precision     uint
 		expected      float64
 		expectederror string
 	}
 
 	tests := []test{
-		{testname: "Both integers", initial: 1, final: 2, expected: 100, expectederror: ""},
-		{testname: "One decimal", initial: 12.5, final: 0, expected: -100, expectederror: ""},
-		{testname: "Both decimals", initial: 100.0, final: 150.0, expected: 50, expectederror: ""},
-		{testname: "Both decimals 1", initial: 12.55, final: 50.456745345, expected: 302.0457796414343, expectederror: ""},
-		{testname: "Both decimals 2", initial: 302.045779641, final: 50.4567453478, expected: -83.29500070890879, expectederror: ""},
-		{testname: "Both decimals 3", initial: 4846545465456.888, final: 2155655.09, expected: -99.9999555218226, expectederror: ""},
-		{testname: "One negative integers", initial: -1, final: 12, expected: 1300, expectederror: ""},
-		{testname: "Two negative integers", initial: -1, final: -10, expected: -900, expectederror: ""},
-		{testname: "On negative decimal", initial: 100.0, final: -150.0, expected: -250, expectederror: ""},
-		{testname: "Both negative decimals", initial: -12.55, final: -50.456745345, expected: -302.0457796414343, expectederror: ""},
-		{testname: "Both negative decimals 1", initial: -302.045, final: -50.4567453478, expected: 83.29495758982934, expectederror: ""},
-		{testname: "Both negative decimals 2", initial: -48465454654.8889, final: -2155655.09, expected: 99.99555218225983, expectederror: ""},
-		{testname: "Zero for initial value", initial: 0, final: 5, expected: 0, expectederror: "Initial value should be non-zero"},
+		{testname: "Both integers", initial: 1, final: 2, precision: 7, expected: 100, expectederror: ""},
+		{testname: "One decimal", initial: 12.5, final: 0, precision: 1, expected: -100, expectederror: ""},
+		{testname: "Both decimals", initial: 100.0, final: 150.0, precision: 3, expected: 50, expectederror: ""},
+		{testname: "Both decimals 1", initial: 12.55, final: 50.456745345, precision: 5, expected: 302.04578, expectederror: ""},
+		{testname: "Both decimals 2", initial: 302.045779641, final: 50.4567453478, precision: 0, expected: -83, expectederror: ""},
+		{testname: "Both decimals 3", initial: 4846545465456.888, final: 2155655.09, precision: 10, expected: -99.9999555218, expectederror: ""},
+		{testname: "One negative integers", initial: -1, final: 12, precision: 5, expected: 1300, expectederror: ""},
+		{testname: "Two negative integers", initial: -1, final: -10, precision: 3, expected: -900, expectederror: ""},
+		{testname: "On negative decimal", initial: 100.0, final: -150.0, precision: 1, expected: -250, expectederror: ""},
+		{testname: "Both negative decimals", initial: -12.55, final: -50.456745345, precision: 4, expected: -302.0458, expectederror: ""},
+		{testname: "Both negative decimals 1", initial: -302.045, final: -50.4567453478, precision: 0, expected: 83, expectederror: ""},
+		{testname: "Both negative decimals 2", initial: -48465454654.8889, final: -2155655.09, precision: 4, expected: 99.9956, expectederror: ""},
+		{testname: "Zero for initial value", initial: 0, final: 5, precision: 2, expected: 0, expectederror: "Initial value should be non-zero"},
 	}
 
 	for _, tc := range tests {
-		actual, actualerr := PercentChange(tc.initial, tc.final)
+		actual, actualerr := PercentChange(tc.initial, tc.final, tc.precision)
 		assert.Equal(t, tc.expected, actual, "Test name: "+tc.testname)
 		if tc.expectederror != "" {
 			assert.EqualError(t, actualerr, tc.expectederror)
@@ -45,23 +46,24 @@ func TestPercentDifference(t *testing.T) {
 		testname      string
 		n1            float64
 		n2            float64
+		precision     uint
 		expected      float64
 		expectederror string
 	}
 
 	tests := []test{
-		{testname: "Both integers", n1: 1, n2: 3, expected: 100, expectederror: ""},
-		{testname: "One decimal", n1: 1, n2: 2.5, expected: 85.71428571428571, expectederror: ""},
-		{testname: "Both decimals", n1: 100.0, n2: 150.0, expected: 40, expectederror: ""},
-		{testname: "Both decimals 1", n1: 12.55, n2: 50.456745345, expected: 120.32599093140797, expectederror: ""},
-		{testname: "Both decimals 2", n1: 302.045779641, n2: 50.4567453478, expected: 142.7445288802931, expectederror: ""},
-		{testname: "Both decimals 3", n1: 4846545465456.888, n2: 2155655.09, expected: 199.99982208736952, expectederror: ""},
-		{testname: "One negative number", n1: -1, n2: 12, expected: 0, expectederror: "Values should be greater than 0"},
-		{testname: "Two negative numbers", n1: -1, n2: -10, expected: 0, expectederror: "Values should be greater than 0"},
+		{testname: "Both integers", n1: 1, n2: 3, precision: 0, expected: 100, expectederror: ""},
+		{testname: "One decimal", n1: 1, n2: 2.5, precision: 2, expected: 85.71, expectederror: ""},
+		{testname: "Both decimals", n1: 100.0, n2: 150.0, precision: 2, expected: 40, expectederror: ""},
+		{testname: "Both decimals 1", n1: 12.55, n2: 50.456745345, precision: 4, expected: 120.326, expectederror: ""},
+		{testname: "Both decimals 2", n1: 302.045779641, n2: 50.4567453478, precision: 5, expected: 142.74453, expectederror: ""},
+		{testname: "Both decimals 3", n1: 4846545465456.888, n2: 2155655.09, precision: 6, expected: 199.999822, expectederror: ""},
+		{testname: "One negative number", n1: -1, n2: 12, precision: 2, expected: 0, expectederror: "Values should be greater than 0"},
+		{testname: "Two negative numbers", n1: -1, n2: -10, precision: 100000, expected: 0, expectederror: "Values should be greater than 0"},
 	}
 
 	for _, tc := range tests {
-		actual, actualerr := PercentDifference(tc.n1, tc.n2)
+		actual, actualerr := PercentDifference(tc.n1, tc.n2, tc.precision)
 		assert.Equal(t, tc.expected, actual, "Test name: "+tc.testname)
 		if tc.expectederror != "" {
 			assert.EqualError(t, actualerr, tc.expectederror)


### PR DESCRIPTION
PercentChange and PercentDIfference functions take precision as argument. They round result to the specific decimal point. 